### PR TITLE
Add a /rebase command

### DIFF
--- a/.github/workflows/ghstack_land.yaml
+++ b/.github/workflows/ghstack_land.yaml
@@ -16,7 +16,7 @@ jobs:
         ${{ toJson(github) }}
         EOF
     - name: Show Github Event Path Json
-      run: 'cat $GITHUB_EVENT_PATH || true'
+      run: 'cat "$GITHUB_EVENT_PATH" || true'
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.LAND_TOKEN }}

--- a/.github/workflows/ghstack_rebase.yaml
+++ b/.github/workflows/ghstack_rebase.yaml
@@ -1,11 +1,11 @@
-name: Land ghstack PRs
+name: Rebase ghstack PRs
 on:
   repository_dispatch:
-    types: [land-command]
+    types: [rebase-command]
 
 jobs:
-  ghstack_land:
-    name: ghstack Land
+  ghstack_rebase:
+    name: ghstack Rebase
     runs-on: ubuntu-latest
     steps:
     - name: Show Environment Variables
@@ -24,18 +24,20 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: 3.9
-    - name: Check Current CI Status
+    - name: Check PR can be rebased
       run: |
         pip install requests ghstack
-        .github/workflows/scripts/ghstack-perm-check.py land <<'EOF'
+        .github/workflows/scripts/ghstack-perm-check.py rebase <<'EOF'
         ${{ toJson(github) }}
         EOF
       env:
         GITHUB_TOKEN: ${{ secrets.LAND_TOKEN }}
-    - name: Land It!
+    - name: Rebase It!
       run: |
+        # Configure Git and GHStack
         git config --global user.email "andrea.frittoli@gmail.com"
         git config --global user.name "Andrea Frittoli"
+
         cat <<EOF > ~/.ghstackrc
         [ghstack]
         github_url = github.com
@@ -43,6 +45,11 @@ jobs:
         github_username = afrittoli
         remote_name = origin
         EOF
-        ghstack land "${{ github.event.client_payload.pull_request.html_url }}"
+
+        # Rebase the stack
+        git rebase origin/main
+
+        # Update the PRs
+        ghstack submit "${{ github.event.client_payload.pull_request.html_url }}"
       env:
         GITHUB_TOKEN: ${{ secrets.LAND_TOKEN }}

--- a/.github/workflows/ghstack_rebase.yaml
+++ b/.github/workflows/ghstack_rebase.yaml
@@ -16,7 +16,7 @@ jobs:
         ${{ toJson(github) }}
         EOF
     - name: Show Github Event Path Json
-      run: 'cat $GITHUB_EVENT_PATH || true'
+      run: 'cat "$GITHUB_EVENT_PATH" || true'
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.LAND_TOKEN }}
@@ -46,7 +46,14 @@ jobs:
         remote_name = origin
         EOF
 
+        # Fetch the latest origin/main
+        git fetch origin/main
+
         # Rebase the stack
+        # The ability to rebase is checked beforehand, but there is a slight chance that
+        # rebase might still fail here if origin/main moved since it was checked.
+        # When that happens the error will be in the action log and the rebase will be
+        # reported as failed.
         git rebase origin/main
 
         # Update the PRs

--- a/.github/workflows/scripts/ghstack-perm-check.py
+++ b/.github/workflows/scripts/ghstack-perm-check.py
@@ -74,9 +74,9 @@ class GHStackChecks:
         )
         return pr_numbers
 
-    def land(self, pr_numbers):
+    def land(self):
         # Enforce requirements for every PR in the stack
-        for n in pr_numbers:
+        for n in self.pr_numbers:
             # Checking Approvals
             print(f":: Checking PR status #{n}... ", end="")
             resp = self.gh.get(f"https://api.github.com/repos/{self.REPO}/pulls/{n}")
@@ -123,7 +123,7 @@ class GHStackChecks:
 
         print(":: All PRs are ready to be landed!")
 
-    def rebase(self, pr_numbers):
+    def rebase(self):
         # Check if the PR owner matches the actor
         actor = self.event["event"]["client_payload"]["github"]["actor"]
         self.must(actor, "Event actor not found!")
@@ -144,7 +144,7 @@ class GHStackChecks:
             permissions = resp.json()
 
             # Check if the actor is an OWNER (permission "write" or "admin")
-            # Reference: https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#check-if-a-user-is-a-repository-collaborator
+            # Reference: https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#check-if-a-user-is-a-repository-collaborator  # noqa: E501
             self.must(
                 permissions["permission"] in ["write", "admin"],
                 f"User {actor} must be a maintainer {self.REPO} to rebase someone else's PR",

--- a/.github/workflows/scripts/ghstack-perm-check.py
+++ b/.github/workflows/scripts/ghstack-perm-check.py
@@ -4,6 +4,7 @@
 # Adapted from github.com/taichi-dev/taichi (Apache 2.0 licensed)
 # Source: https://github.com/taichi-dev/taichi/blob/master/.github/workflows/scripts/ghstack-perm-check.py
 
+import argparse
 import json
 import os
 import re
@@ -12,99 +13,147 @@ import sys
 
 import requests
 
+class GHStackChecks:
 
-def main():
-    gh = requests.Session()
-    gh.headers.update(
-        {
-            "Authorization": f'Bearer {os.environ["GITHUB_TOKEN"]}',
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
-    )
-    EV = json.loads(sys.stdin.read())
-    REPO = EV["repository"]
-    PR = EV["event"]["client_payload"]["pull_request"]
-    NUMBER = PR["number"]
+    def __init__(self, token, event):
+        self.gh = requests.Session()
+        self.gh.headers.update(
+                {
+                    "Authorization": f'Bearer {token}',
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                }
+            )
+        self.event = event
+        self.REPO = event["repository"]
+        self.PR = event["event"]["client_payload"]["pull_request"]
+        self.NUMBER = self.PR["number"]
+        self.pr_numbers = self.shared_checks()
 
-    def must(cond, msg):
+    def must(self, cond, msg):
         if not cond:
             print(msg)
-            gh.post(
-                f"https://api.github.com/repos/{REPO}/issues/{NUMBER}/comments",
+            self.gh.post(
+                f"https://api.github.com/repos/{self.REPO}/issues/{self.NUMBER}/comments",
                 json={
                     "body": f"ghstack bot failed: {msg}",
                 },
             )
             exit(1)
 
-    head_ref = PR["head"]["ref"]
-    must(
-        head_ref and re.match(r"^gh/[A-Za-z0-9-]+/[0-9]+/head$", head_ref),
-        "Not a ghstack PR",
-    )
-    orig_ref = head_ref.replace("/head", "/orig")
-    print(":: Fetching newest main...")
-    must(os.system("git fetch origin main") == 0, "Can't fetch main")
-    print(":: Fetching orig branch...")
-    must(os.system(f"git fetch origin {orig_ref}") == 0, "Can't fetch orig branch")
+    def shared_checks(self):
+        head_ref = self.PR["head"]["ref"]
+        self.must(
+            head_ref and re.match(r"^gh/[A-Za-z0-9-]+/[0-9]+/head$", head_ref),
+            "Not a ghstack PR",
+        )
+        orig_ref = head_ref.replace("/head", "/orig")
+        print(":: Fetching newest main...")
+        self.must(os.system("git fetch origin main") == 0, "Can't fetch main")
+        print(":: Fetching orig branch...")
+        self.must(os.system(f"git fetch origin {orig_ref}") == 0, "Can't fetch orig branch")
 
-    proc = subprocess.Popen(
-        "git log FETCH_HEAD...$(git merge-base FETCH_HEAD origin/main)",
-        stdout=subprocess.PIPE,
-        shell=True,
-    )
-    out, _ = proc.communicate()
-    must(proc.wait() == 0, "`git log` command failed!")
+        proc = subprocess.Popen(
+            "git log FETCH_HEAD...$(git merge-base FETCH_HEAD origin/main)",
+            stdout=subprocess.PIPE,
+            shell=True,
+        )
+        out, _ = proc.communicate()
+        self.must(proc.wait() == 0, "`git log` command failed!")
 
-    pr_numbers = re.findall(
-        r"Pull Request resolved: https://github.com/.*?/pull/([0-9]+)",
-        out.decode("utf-8"),
-    )
-    pr_numbers = list(map(int, pr_numbers))
-    must(pr_numbers and pr_numbers[0] == NUMBER, "Extracted PR numbers not seems right!")
+        pr_numbers = re.findall(
+            r"Pull Request resolved: https://github.com/.*?/pull/([0-9]+)",
+            out.decode("utf-8"),
+        )
+        pr_numbers = list(map(int, pr_numbers))
+        self.must(pr_numbers and pr_numbers[0] == self.NUMBER, "Extracted PR numbers not seems right!")
+        return pr_numbers
 
-    for n in pr_numbers:
-        print(f":: Checking PR status #{n}... ", end="")
-        resp = gh.get(f"https://api.github.com/repos/{REPO}/pulls/{n}")
-        must(resp.ok, "Error Getting PR Object!")
-        pr_obj = resp.json()
+    def land(self, pr_numbers):
 
-        resp = gh.get(f"https://api.github.com/repos/{REPO}/pulls/{NUMBER}/reviews")
-        must(resp.ok, "Error Getting PR Reviews!")
-        reviews = resp.json()
-        idmap = {}
-        approved = False
-        for r in reviews:
-            s = r["state"]
-            if s not in ("COMMENTED",):
-                idmap[r["user"]["login"]] = r["state"]
+        # Enforce requirements for every PR in the stack
+        for n in pr_numbers:
+            # Checking Approvals
+            print(f":: Checking PR status #{n}... ", end="")
+            resp = self.gh.get(f"https://api.github.com/repos/{self.REPO}/pulls/{n}")
+            self.must(resp.ok, "Error Getting PR Object!")
+            pr_obj = resp.json()
 
-        for u, cc in idmap.items():
-            approved = approved or cc == "APPROVED"
-            must(
-                cc in ("APPROVED", "DISMISSED"),
-                f"@{u} has stamped PR #{n} `{cc}`, please resolve it first!",
-            )
+            resp = self.gh.get(f"https://api.github.com/repos/{self.REPO}/pulls/{self.NUMBER}/reviews")
+            self.must(resp.ok, "Error Getting PR Reviews!")
+            reviews = resp.json()
+            idmap = {}
+            approved = False
+            for r in reviews:
+                s = r["state"]
+                if s not in ("COMMENTED",):
+                    idmap[r["user"]["login"]] = r["state"]
 
-        must(approved, f"PR #{n} is not approved yet!")
+            for u, cc in idmap.items():
+                approved = approved or cc == "APPROVED"
+                self.must(
+                    cc in ("APPROVED", "DISMISSED"),
+                    f"@{u} has stamped PR #{n} `{cc}`, please resolve it first!",
+                )
 
-        resp = gh.get(f'https://api.github.com/repos/{REPO}/commits/{pr_obj["head"]["sha"]}/check-runs')
-        must(resp.ok, "Error getting check runs status!")
-        checkruns = resp.json()
-        for cr in checkruns["check_runs"]:
-            status = cr.get("conclusion", cr["status"])
-            name = cr["name"]
-            if name == "Copilot for PRs":
-                continue
-            must(
-                status in ("success", "neutral"),
-                f"PR #{n} check-run `{name}`'s status `{status}` is not success!",
-            )
-        print("SUCCESS!")
+            self.must(approved, f"PR #{n} is not approved yet!")
 
-    print(":: All PRs are ready to be landed!")
+            # Checking CI Jobs
+            resp = self.gh.get(f'https://api.github.com/repos/{self.REPO}/commits/{pr_obj["head"]["sha"]}/check-runs')
+            self.must(resp.ok, "Error getting check runs status!")
+            checkruns = resp.json()
+            for cr in checkruns["check_runs"]:
+                status = cr.get("conclusion", cr["status"])
+                name = cr["name"]
+                if name == "Copilot for PRs":
+                    continue
+                self.must(
+                    status in ("success", "neutral"),
+                    f"PR #{n} check-run `{name}`'s status `{status}` is not success!",
+                )
+            print("SUCCESS!")
+
+        print(":: All PRs are ready to be landed!")
+
+    def rebase(self, pr_numbers):
+        # Check if the PR owner matches the actor
+        actor = self.event["event"]["client_payload"]["github"]["actor"]
+        self.must(actor, "Event actor not found!")
+
+        pr_owner = self.PR["user"]["login"]
+        self.must(actor, "PR Owner not found!")
+
+        # If the comment was not left by the owner, it's only allowed for owners
+        if actor != pr_owner:
+            # Get the user permissions on the repo
+            resp = self.gh.get(f"https://api.github.com/repos/{self.REPO}/collaborators/{actor}/permission")
+            self.must(resp.ok, f"User {actor} must be a maintainer {self.REPO} to rebase someone else's PR")
+            permissions = resp.json()
+
+            # Check if the actor is an OWNER (permission "write" or "admin")
+            # Reference: https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#check-if-a-user-is-a-repository-collaborator
+            self.must(permissions["permission"] in ["write", "admin"], f"User {actor} must be a maintainer {self.REPO} to rebase someone else's PR")
+
+        # Attempt to rebase, fail in case of merge conflicts
+        print(":: Attempting a rebase on main...")
+        self.must(os.system("git rebase origin/main") == 0, "Can't rebase on main")
+        print(":: All PRs are ready to be rebased!")
+
+def main(check):
+    # Setup the wrapper class
+    EV = json.loads(sys.stdin.read())
+    ghstack_checks = GHStackChecks(os.environ["GITHUB_TOKEN"], EV)
+
+    # Run the github action specific checks
+    if check == "land":
+        ghstack_checks.land()
+    elif check == "rebase":
+        ghstack_checks.rebase()
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description='GHStack Permission Checks')
+    parser.add_argument('check', choices=['land', 'rebase'])
+    args = parser.parse_args()
+
+    main(args.check)

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -25,5 +25,11 @@ jobs:
               "permission": "none",
               "issue_type": "issue",
               "repository": "afrittoli/sandbox"
+            },
+            {
+              "command": "rebase",
+              "permission": "none",
+              "issue_type": "pull-request",
+              "repository": "afrittoli/sandbox"
             }
           ]

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# Python
+**/__pycache__
+
 # Go workspace file
 go.work


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #20

Let users rebase their ghstack stacks by leaving a /rebase comment
on a PR. This action is only permitted if the commenter is the
owner of the PR or a maintainer of the repo.

The action acts using the fms-bot account, it attempts to
rebase (git rebase origin/main), and if no conflicts are found, it
pushes the rebase via ghstack.

Note that the fms-bot is not the same account as the author or the PRs
The original author(s) will be preserved in the it log, but the committer
will be set to fms-bot.

If the rebase command is issued on a PR that is not the top PR of
a stack, the rebase command will only rebase the PR where the
comment was issued and those underneath it in the stack.

The python code that performs the checks for the "/land" command has
been refactored, shared checks have been separated so that they may
be reused by other commands, like the "/rebase" implemented here.

Shared checks verify that the PR is formatted according to ghstack
requirements and attempt to extract the list of PRs in the stack.

Fixes #142

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>